### PR TITLE
Remove code referencing an unsatisfied dependency

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,21 +1,6 @@
-// This file was automatically added by layer0 init.
-// You should commit this file to source control.
-const { withLayer0, withServiceWorker } = require('@layer0/next/config')
-
-const _preLayer0Export = {
+module.exports = {
   reactStrictMode: true,
   images: {
     domains: ['static.tvmaze.com'],
   },
 }
-
-module.exports = (phase, config) =>
-  withLayer0(
-    withServiceWorker({
-      // Output sourcemaps so that stack traces have original source filenames and line numbers when tailing
-      // the logs in the Layer0 developer console.
-      layer0SourceMaps: true,
-
-      ..._preLayer0Export,
-    })
-  )


### PR DESCRIPTION
This fixes `npm run dev` bailing with 
```
error - Module not found: Error: Can't resolve '/Users/bart/projects/onboarding/layer0-netflix/sw/service-worker.js' in '...
```
_before_ `0 init`.
